### PR TITLE
Setup initial project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "ecommerce-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.11.16",
+    "@mui/material": "^5.13.0",
+    "@mui/x-data-grid": "^6.3.0",
+    "@types/node": "^18.16.3",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.1",
+    "i18next": "^22.4.15",
+    "i18next-browser-languagedetector": "^7.0.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-i18next": "^12.2.2",
+    "react-router-dom": "^6.11.0",
+    "typescript": "^5.0.4",
+    "web-vitals": "^3.3.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import { theme } from './theme';
+import Layout from './components/Layout';
+import AppRoutes from './routes';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Layout>
+          <AppRoutes />
+        </Layout>
+      </ThemeProvider>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { styled } from '@mui/material/styles';
+import {
+  Box,
+  Drawer,
+  AppBar,
+  Toolbar,
+  Typography,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material';
+import {
+  Menu as MenuIcon,
+  Dashboard as DashboardIcon,
+  Inventory as ProductsIcon,
+  ShoppingCart as OrdersIcon,
+  People as CustomersIcon,
+} from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+
+const drawerWidth = 240;
+
+const Main = styled('main')(({ theme }) => ({
+  flexGrow: 1,
+  padding: theme.spacing(3),
+  marginLeft: drawerWidth,
+}));
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const Layout: React.FC<LayoutProps> = ({ children }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const menuItems = [
+    { text: t('dashboard'), icon: <DashboardIcon />, path: '/' },
+    { text: t('products'), icon: <ProductsIcon />, path: '/products' },
+    { text: t('orders'), icon: <OrdersIcon />, path: '/orders' },
+    { text: t('customers'), icon: <CustomersIcon />, path: '/customers' },
+  ];
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <AppBar position="fixed" sx={{ zIndex: 1201 }}>
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            edge="start"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            sx={{ mr: 2, display: { sm: 'none' } }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" noWrap>
+            eCommerce Dashboard
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Drawer
+        variant="permanent"
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        <Toolbar />
+        <Divider />
+        <List>
+          {menuItems.map((item) => (
+            <ListItem
+              button
+              key={item.text}
+              onClick={() => navigate(item.path)}
+            >
+              <ListItemIcon>{item.icon}</ListItemIcon>
+              <ListItemText primary={item.text} />
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+      <Main>
+        <Toolbar />
+        {children}
+      </Main>
+    </Box>
+  );
+};
+
+export default Layout;

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,27 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'en',
+    resources: {
+      en: {
+        translation: {
+          dashboard: 'Dashboard',
+          products: 'Products',
+          orders: 'Orders',
+          customers: 'Customers',
+          analytics: 'Analytics',
+          settings: 'Settings'
+        }
+      }
+    },
+    interpolation: {
+      escapeValue: false
+    }
+  });
+
+export default i18n;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+import './i18n/config';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/Customers/index.tsx
+++ b/src/pages/Customers/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+
+const Customers = () => {
+  return (
+    <Typography variant="h4" component="h1">
+      Customers
+    </Typography>
+  );
+};
+
+export default Customers;

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+
+const Dashboard = () => {
+  return (
+    <Typography variant="h4" component="h1">
+      Dashboard
+    </Typography>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Orders/index.tsx
+++ b/src/pages/Orders/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+
+const Orders = () => {
+  return (
+    <Typography variant="h4" component="h1">
+      Orders
+    </Typography>
+  );
+};
+
+export default Orders;

--- a/src/pages/Products/index.tsx
+++ b/src/pages/Products/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+
+const Products = () => {
+  return (
+    <Typography variant="h4" component="h1">
+      Products
+    </Typography>
+  );
+};
+
+export default Products;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Dashboard from '../pages/Dashboard';
+import Products from '../pages/Products';
+import Orders from '../pages/Orders';
+import Customers from '../pages/Customers';
+
+const AppRoutes = () => {
+  return (
+    <Routes>
+      <Route path="/" element={<Dashboard />} />
+      <Route path="/products" element={<Products />} />
+      <Route path="/orders" element={<Orders />} />
+      <Route path="/customers" element={<Customers />} />
+    </Routes>
+  );
+};
+
+export default AppRoutes;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,12 @@
+import { createTheme } from '@mui/material/styles';
+
+export const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#dc004e',
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This PR sets up the initial project structure with:

- React with TypeScript
- Material-UI (MUI) components and theme
- React Router for navigation
- i18n for internationalization
- Basic layout with sidebar navigation
- Initial pages for Dashboard, Products, Orders, and Customers

The project is ready to be cloned and run locally using:
```bash
git clone <repository-url>
cd ecommerce-dashboard
npm install
npm start
```